### PR TITLE
updated systemu gem to 2.4.0 to play nice with ruby 1.9.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+.bundle
+.rvmrc
+vendor
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,2 @@
+source "http://rubygems.org"
+gemspec

--- a/README
+++ b/README
@@ -16,6 +16,11 @@ INSTALL
   gem install macaddr
 
 HISTORY
+  New:
+    - added a Gemfile for easier testing/dev with Bundler
+    - added an example .rvmrc file that will setup for ruby 1.9.3
+    - updated systemu gem to ~>2.4.0 to work with ruby 1.9.3
+
   1.1.0:
     - added dependancy on systemu to work around butt-licky windoze io
       capture: http://redmine.ruby-lang.org/issues/show/3215

--- a/macaddr.gemspec
+++ b/macaddr.gemspec
@@ -28,7 +28,7 @@ Gem::Specification::new do |spec|
   spec.test_files = nil
 
   
-    spec.add_dependency(*["systemu", "~> 2.2.0"])
+    spec.add_dependency(*["systemu", "~> 2.4.0"])
   
 
   spec.extensions.push(*[])

--- a/rvmrc.example
+++ b/rvmrc.example
@@ -1,0 +1,1 @@
+rvm use --create ruby-1.9.3@macaddr


### PR DESCRIPTION
I did two things here.

1 -  update to systemu 2.4.0 to avoid warnings from ruby 1.9.3

I was getting...
/Volumes/Code/xxxxx/vendor/ruby/1.9.1/gems/systemu-2.2.0/lib/systemu.rb:29: Use RbConfig instead of obsolete and deprecated Config.

2 - added a Gemfile and .gitignore to make dev/testing easier with Bundler/RVM
