### PR TITLE
Update systemu dependency to 2.5.0

### DIFF
--- a/macaddr.gemspec
+++ b/macaddr.gemspec
@@ -31,7 +31,7 @@ Gem::Specification::new do |spec|
   spec.test_files = nil
 
   
-    spec.add_dependency(*["systemu", "~> 2.2.0"])
+    spec.add_dependency(*["systemu", "~> 2.5.0"])
   
 
   spec.extensions.push(*[])


### PR DESCRIPTION
The latest version of systemu is 2.5.0. To correct the recent downgrade
to 2.2.0 that has deprecation warnings on Ruby 1.9.3, the dependency has
been updated to use the latest systemu.

This should help correct #10.
