### PR TITLE
re-adding the dependency on systemu. unsure of the version I included bo...

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -128,6 +128,9 @@ task :gemspec do
 
             spec.test_files = #{ test_files.inspect }
 
+            spec.add_runtime_dependency "systemu", "~> 2.5.2"
+            # spec.add_runtime_dependency "systemu", "~> 2.6.2"
+
           ### spec.add_dependency 'lib', '>= version'
           #### spec.add_dependency 'map'
 

--- a/macaddr.gemspec
+++ b/macaddr.gemspec
@@ -31,6 +31,9 @@ Gem::Specification::new do |spec|
 
   spec.test_files = nil
 
+  spec.add_runtime_dependency "systemu", "~> 2.5.2"
+  # spec.add_runtime_dependency "systemu", "~> 2.6.2"
+
 ### spec.add_dependency 'lib', '>= version'
 #### spec.add_dependency 'map'
 


### PR DESCRIPTION
This adds back the runtime dependency on the systemu gem. I wasn't sure which version should be used so I added 2.5.0 which was what was there previously, however I also included the newest version (2.6.2) as an option.
