### PR TITLE
Change license name to conform to SPDX standard

### DIFF
--- a/macaddr.gemspec
+++ b/macaddr.gemspec
@@ -7,7 +7,7 @@ Gem::Specification::new do |spec|
   spec.platform = Gem::Platform::RUBY
   spec.summary = "macaddr"
   spec.description = "cross platform mac address determination for ruby"
-  spec.license = "same as ruby's"
+  spec.license = "Ruby"
 
   spec.files =
 ["Gemfile",


### PR DESCRIPTION
http://spdx.org/licenses/

This will help with automated processing of licenses, e.g. for those trying to package this gem with many others and ensure that all are under compatible licenses.
