### PR TITLE
check for addr before evaluating it,  e.g. tun type interfaces

### DIFF
--- a/lib/macaddr.rb
+++ b/lib/macaddr.rb
@@ -83,7 +83,9 @@ module Mac
       return unless Socket.respond_to? :getifaddrs
 
       interfaces = Socket.getifaddrs.select do |addr|
-        addr.addr.pfamily == INTERFACE_PACKET_FAMILY
+        if addr.addr  # Some VPN ifcs don't have an addr - ignore them
+          addr.addr.pfamily == INTERFACE_PACKET_FAMILY
+        end
       end
 
       mac, =


### PR DESCRIPTION
Currently this tries to evaluate addr for all interfaces and this may not be appropriate, for instance when running openvpn on Ubuntu it fails on the resulting tun interface.  This just checks that addr exists before getting the pfamily property.  Tested on Ubuntu 12.04 and 14.04.
