### PR TITLE
fix for nil addrs

### DIFF
--- a/lib/macaddr.rb
+++ b/lib/macaddr.rb
@@ -83,7 +83,7 @@ module Mac
       return unless Socket.respond_to? :getifaddrs
 
       interfaces = Socket.getifaddrs.select do |addr|
-        addr.addr.pfamily == INTERFACE_PACKET_FAMILY
+        addr.addr && addr.addr.pfamily == INTERFACE_PACKET_FAMILY
       end
 
       mac, =


### PR DESCRIPTION
fix `NoMethodError: undefined method 'pfamily' for nil:NilClass`

I'm on Arch Linux.
```
[1] pry(main)> Mac.addr.list                                                                                                                                                                                       
NoMethodError: undefined method `pfamily' for nil:NilClass
from /home/sergey/.rvm/gems/ruby-x.x.x@gemset/gems/macaddr-1.7.1/lib/macaddr.rb:86:in `block in from_getifaddrs'
[2] pry(main)> Socket.getifaddrs
=> [#<Socket::Ifaddr lo UP,LOOPBACK,RUNNING,0x10000 PACKET[protocol=0 lo hatype=772 HOST hwaddr=00:00:00:00:00:00]>,
 #<Socket::Ifaddr enp4s0 UP,BROADCAST,MULTICAST PACKET[protocol=0 enp4s0 hatype=1 HOST hwaddr=d0:50:99:27:1d:d6] broadcast=PACKET[protocol=0 enp4s0 hatype=1 HOST hwaddr=ff:ff:ff:ff:ff:ff]>,
 #<Socket::Ifaddr wlp0s20u12 UP,BROADCAST,RUNNING,MULTICAST,0x10000 PACKET[protocol=0 wlp0s20u12 hatype=1 HOST hwaddr=c0:4a:00:25:39:0c] broadcast=PACKET[protocol=0 wlp0s20u12 hatype=1 HOST hwaddr=ff:ff:ff:ff:ff:ff]>,
 #<Socket::Ifaddr tun0 UP,POINTOPOINT,RUNNING,NOARP,MULTICAST,0x10000>,
 #<Socket::Ifaddr lo UP,LOOPBACK,RUNNING,0x10000 127.0.0.1 netmask=255.0.0.0>,
 #<Socket::Ifaddr wlp0s20u12 UP,BROADCAST,RUNNING,MULTICAST,0x10000 192.168.0.105 netmask=255.255.255.0 broadcast=192.168.0.255>,
 #<Socket::Ifaddr tun0 UP,POINTOPOINT,RUNNING,NOARP,MULTICAST,0x10000 172.27.233.99 netmask=255.255.248.0 dstaddr=172.27.239.255>,
 #<Socket::Ifaddr lo UP,LOOPBACK,RUNNING,0x10000 ::1 netmask=ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff>,
 #<Socket::Ifaddr enp4s0 UP,BROADCAST,MULTICAST fe80::6550:af3d:d75d:ebad%enp4s0 netmask=ffff:ffff:ffff:ffff::>,
 #<Socket::Ifaddr wlp0s20u12 UP,BROADCAST,RUNNING,MULTICAST,0x10000 fe80::7b31:5017:7bf:d03d%wlp0s20u12 netmask=ffff:ffff:ffff:ffff::>]
[3] pry(main)> Socket.getifaddrs.map &:addr
=> [#<Addrinfo: PACKET[protocol=0 lo hatype=772 HOST hwaddr=00:00:00:00:00:00]>,
 #<Addrinfo: PACKET[protocol=0 enp4s0 hatype=1 HOST hwaddr=d0:50:99:27:1d:d6]>,
 #<Addrinfo: PACKET[protocol=0 wlp0s20u12 hatype=1 HOST hwaddr=c0:4a:00:25:39:0c]>,
 nil,
 #<Addrinfo: 127.0.0.1>,
 #<Addrinfo: 192.168.0.105>,
 #<Addrinfo: 172.27.233.99>,
 #<Addrinfo: ::1>,
 #<Addrinfo: fe80::6550:af3d:d75d:ebad%enp4s0>,
 #<Addrinfo: fe80::7b31:5017:7bf:d03d%wlp0s20u12>]
```

@ahoward it's a quick patch. Should I write tests?