### PR TITLE
1.8.0 refactor and allow for Mac.addr.list to work via Mac::from_getifaddrs

### DIFF
--- a/macaddr.gemspec
+++ b/macaddr.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification::new do |spec|
   spec.name = "macaddr"
-  spec.version = "1.7.2"
+  spec.version = "1.8.0"
   spec.platform = Gem::Platform::RUBY
   spec.summary = "macaddr"
   spec.description = "cross platform mac address determination for ruby"
@@ -27,14 +27,12 @@ Gem::Specification::new do |spec|
  "test/testing.rb"]
 
   spec.executables = []
-  
+
   spec.require_path = "lib"
 
   spec.test_files = nil
 
-  
-    spec.add_dependency(*["systemu", "~> 2.6.5"])
-  
+  spec.add_dependency(*["systemu", "~> 2.6.5"])
 
   spec.extensions.push(*[])
 


### PR DESCRIPTION
I was having some issues around running `Mac.addr.list`. I saw the issue was that `list` method wasn't being defined on the `Mac.addr` return value when it used `Mac.from_getifaddrs` to set the value. So I fixed that, and also did a bit of refactoring to get a better feel for what all is happening while maintaining the original API.

This should fix issue https://github.com/ahoward/macaddr/issues/26

Test and works on OSX and Fedora 31, both using Ruby 2.6.3.