### PR TITLE
Update source in Gemfile to HTTPS

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 gemspec


### PR DESCRIPTION
[Sonatype Nexus](https://www.sonatype.com/) scanners are flagging this as a false positive of a possible man-in-the-middle attack when applications depend on the macaddr gem.

A patch-level version bump would be much appreciated.

/cc @ahoward 